### PR TITLE
Occlude FloatingTextComponent created on counter destruction

### DIFF
--- a/src/main/java/org/terasology/MineSweeper/system/MinesweeperSystem.java
+++ b/src/main/java/org/terasology/MineSweeper/system/MinesweeperSystem.java
@@ -172,7 +172,10 @@ public class MinesweeperSystem extends BaseComponentSystem {
         EntityRef ref = entityManager.create();
         ref.addComponent(new LocationComponent()).setWorldPosition(blockComponent.getPosition().toVector3f());
         ref.addComponent(new FloatingCountComponent()).neighbors = mines.size();
-        ref.addComponent(new FloatingTextComponent()).text = mines.size() + "";
+
+        FloatingTextComponent floatingTextComponent = new FloatingTextComponent();
+        floatingTextComponent.isOccluded = true;
+        ref.addComponent(floatingTextComponent).text = mines.size() + "";
 
     }
 

--- a/src/main/java/org/terasology/MineSweeper/system/MinesweeperSystem.java
+++ b/src/main/java/org/terasology/MineSweeper/system/MinesweeperSystem.java
@@ -174,7 +174,7 @@ public class MinesweeperSystem extends BaseComponentSystem {
         ref.addComponent(new FloatingCountComponent()).neighbors = mines.size();
 
         FloatingTextComponent floatingTextComponent = new FloatingTextComponent();
-        floatingTextComponent.isOccluded = true;
+        floatingTextComponent.isOverlay = true;
         ref.addComponent(floatingTextComponent).text = mines.size() + "";
 
     }

--- a/src/main/java/org/terasology/MineSweeper/system/MinesweeperSystem.java
+++ b/src/main/java/org/terasology/MineSweeper/system/MinesweeperSystem.java
@@ -174,7 +174,7 @@ public class MinesweeperSystem extends BaseComponentSystem {
         ref.addComponent(new FloatingCountComponent()).neighbors = mines.size();
 
         FloatingTextComponent floatingTextComponent = new FloatingTextComponent();
-        floatingTextComponent.isOverlay = true;
+        floatingTextComponent.isOverlay = false;
         ref.addComponent(floatingTextComponent).text = mines.size() + "";
 
     }


### PR DESCRIPTION
Sets `isOccluded` on the `FloatingTextComponent` created on counter destruction to true so that the floating text is occluded or hidden when behind an object.

Requires MovingBlocks/Terasology#3154 to be merged first.