### PR TITLE
Add max mine limit check for all neighbors when mine is added

### DIFF
--- a/src/main/java/org/terasology/MineSweeper/generator/MineField.java
+++ b/src/main/java/org/terasology/MineSweeper/generator/MineField.java
@@ -34,8 +34,23 @@ public class MineField {
 
     private Set<Vector3i> mines = new HashSet<>();
 
+    private Set<Vector3i> getNeighbors(Vector3i pos) {
+        Set<Vector3i> neighbors = new HashSet<>();
+
+        for (int x = pos.x - 1; x <= pos.x + 1; x++) {
+            for (int y = pos.y - 1; y <= pos.y + 1; y++) {
+                for (int z = pos.z - 1; z <= pos.z + 1; z++) {
+                    Vector3i neighbor = new Vector3i(x, y, z);
+                    neighbors.add(neighbor);
+                }
+            }
+        }
+
+        return neighbors;
+    }
+
     public void addMines(Vector3i mine) {
-        if(getNumberOfNeighbors(mine) < 16) {
+        if(getNeighbors(mine).stream().allMatch(neighbor -> getNumberOfNeighbors(neighbor) < 16)) {
             this.mines.add(mine);
         }
     }


### PR DESCRIPTION
Perform the maximum neighboring mines limit check for _all_ neighboring blocks before a mine is added to ensure that no block in a mine field has more than 16 mines as neighbors.

Closes #3 and fixes #4.

## Testing
Create a new world with the Minesweeper module enabled. You should not run into the NullPointerException detailed in #4.